### PR TITLE
升级依赖包版本。

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dio: ^3.0.10
+  dio: ^4.0.6
   url_launcher: ^5.1.2
   crypto: ^2.1.5
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
   dio: ^4.0.6
-  url_launcher: ^5.1.2
-  crypto: ^2.1.5
+  url_launcher: ^6.0.20
+  crypto: ^3.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
解决flutter pub get冲突
Because every version of flutter_baidu_pan from git depends on dio ^3.0.10 which depends on http_parser >=0.0.1 <4.0.0, every version of flutter_baidu_pan from git requires http_parser >=0.0.1 <4.0.0.
And because http >=0.13.0 depends on http_parser ^4.0.0, flutter_baidu_pan from git is incompatible with http >=0.13.0.